### PR TITLE
Network Manager - Error Handling

### DIFF
--- a/google-news-reader/google-news-reader.xcodeproj/project.pbxproj
+++ b/google-news-reader/google-news-reader.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "google-news-reader/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "nyc.Lieberman.google-news-reader";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -428,6 +429,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "google-news-reader/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "nyc.Lieberman.google-news-reader";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/google-news-reader/google-news-reader/API/NetworkManager.swift
+++ b/google-news-reader/google-news-reader/API/NetworkManager.swift
@@ -8,15 +8,47 @@
 
 import UIKit
 
+enum NetworkError: ErrorType {
+    case NetworkFailure
+    case ParsingError
+    case UnknownError
+}
+
 class NetworkManager: NSObject {
 
-    func fetchAllArticlesWithCompletion(completion: (data: AnyObject?, error: NSError?) -> Void) {
+    func fetchAllArticlesWithCompletion(completion: (data: AnyObject?, error: ErrorType?) -> Void) {
         
         let request = NSURLRequest(URL: NSURL(string: "http://news.google.com/?output=rss")!)
         
         NSURLSession.sharedSession().dataTaskWithRequest(request) { (data, response, error) -> Void in
             
-            completion(data: data, error: error)
+            print("data: \(data)")
+            print("response: \(response)")
+            print("error: \(error)")
+            
+            if let parsedResponse = response as? NSHTTPURLResponse {
+                
+                if (data != nil) && (error == nil) && (parsedResponse.statusCode == 200) {
+                    // good data, no error, good response status code
+                    completion(data: data, error: nil)
+                } else {
+                    if error != nil {
+                        // check error returned first
+                        if let errorCode = error?.code {
+                            switch errorCode {
+                            case 1009:
+                                completion(data: nil, error: NetworkError.NetworkFailure)
+                                
+                            default:
+                                completion(data: nil, error: NetworkError.UnknownError)
+                            }
+                        }
+                    } else {
+                        // non-success status codes and catch all
+                        completion(data: nil, error: NetworkError.UnknownError)
+                    }
+                }
+            }
         }.resume()
     }
     

--- a/google-news-reader/google-news-reader/API/NetworkManager.swift
+++ b/google-news-reader/google-news-reader/API/NetworkManager.swift
@@ -12,6 +12,19 @@ enum NetworkError: ErrorType {
     case NetworkFailure
     case ParsingError
     case UnknownError
+    
+    var localizedDescription: String {
+        switch self {
+        case .NetworkFailure:
+            return "No Network Connection"
+            
+        case .ParsingError:
+            return "Data Parsing Error"
+            
+        default:
+            return "Unknown Error"
+        }
+    }
 }
 
 class NetworkManager: NSObject {

--- a/google-news-reader/google-news-reader/ViewController.swift
+++ b/google-news-reader/google-news-reader/ViewController.swift
@@ -18,6 +18,7 @@ class ViewController: UIViewController {
             if let unwrappedData = data as? NSData {
                 NetworkManager().parseAllArticleData(unwrappedData, completion: { (content, error) -> Void in
                     print(content)
+                    print(error)
                 })
             }
         }


### PR DESCRIPTION
Created NetworkError ErrorType to handle NetworkManager errors.

Switch deployment target from 9.0 to 8.1 to test on personal devices.
