### PR TITLE
Article Prototype - Parsing XML

### DIFF
--- a/google-news-reader/google-news-reader/API/ArticleParser.swift
+++ b/google-news-reader/google-news-reader/API/ArticleParser.swift
@@ -8,14 +8,22 @@
 
 import UIKit
 
+struct ArticlePrototype {
+    var title: String!
+    var description: String!
+    var imageURL: String? // can use placeholder
+}
+
 class ArticleParser: NSObject {
     
     var data: NSData!
     var parser: NSXMLParser!
     
     var element = ""
-    var titles = [String]()
-    var title = ""
+    var articles = [ArticlePrototype]()
+    var articleTitle = ""
+    var articleDescription = ""
+    var articleImageURL = ""
     
     convenience init (data: NSData) {
         self.init()
@@ -27,6 +35,7 @@ class ArticleParser: NSObject {
     
     func parseDataWithCompletion(completion: (success: Bool) -> Void) {
         completion(success: self.parser.parse())
+        
     }
 }
 
@@ -39,24 +48,51 @@ extension ArticleParser: NSXMLParserDelegate {
         self.element = elementName
         
         if self.element == "item" {
-            // next element, clear title
-            self.title = ""
+            // next element, clear properties
+            self.articleTitle = ""
+            self.articleDescription = ""
+            self.articleImageURL = ""
         }
     }
     
     func parser(parser: NSXMLParser, foundCharacters string: String) {
         if self.element == "title" {
-            self.title += string
+            self.articleTitle += string
+        }
+        
+        if self.element == "description" {
+            self.articleDescription += string
         }
     }
     
     func parser(parser: NSXMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
         
         if elementName == "item" {
-            if !self.title.isEmpty {
-                self.titles.append(self.title)
-                print(self.title)
+            if !self.articleTitle.isEmpty && !self.articleDescription.isEmpty {
+                
+                let article = ArticlePrototype(title: self.articleTitle, description: self.self.stringByStrippingHTML(articleDescription), imageURL: "")
+                
+                self.articles.append(article)
+                print(self.articleTitle)
             }
         }
+    }
+    
+    func stringByStrippingHTML(input: String) -> String {
+        
+        let stringlength = input.characters.count
+        var newString = ""
+        
+        do {
+            let regex = try NSRegularExpression(pattern: "<[^>]+>", options: NSRegularExpressionOptions.CaseInsensitive)
+            
+            newString = regex.stringByReplacingMatchesInString(input, options: NSMatchingOptions.ReportCompletion, range: NSMakeRange(0, stringlength), withTemplate: "")
+            
+            print(newString)
+        } catch {
+            print(error)
+        }
+        
+        return newString
     }
 }

--- a/google-news-reader/google-news-reader/API/NetworkManager.swift
+++ b/google-news-reader/google-news-reader/API/NetworkManager.swift
@@ -65,15 +65,15 @@ class NetworkManager: NSObject {
         }.resume()
     }
     
-    func parseAllArticleData(data: NSData, completion: (content: [String]?, error: NSError?) -> Void) {
+    func parseAllArticleData(data: NSData, completion: (content: [ArticlePrototype]?, error: ErrorType?) -> Void) {
         
         let articleParser = ArticleParser(data: data)
         
         articleParser.parseDataWithCompletion { (success) -> Void in
             if success {
-                completion(content: articleParser.titles, error: nil)
+                completion(content: articleParser.articles, error: nil)
             } else {
-                completion(content: nil, error: nil)
+                completion(content: nil, error: NetworkError.ParsingError)
             }
         }
     }


### PR DESCRIPTION
Work on article prototype struct and description.

So the description of each item is actually valid HTML and renders something like this:

<img width="631" alt="screen shot 2015-07-25 at 9 08 03 pm" src="https://cloud.githubusercontent.com/assets/4513736/8892067/492c346c-3311-11e5-9021-b0cb92de7509.png">

Unfortunately, we really only need the article description/abstract.  This gives us a few options.
1. Parse the HTML using some HTTP parsing library - I'd rather not bring in outside dependencies into this project.
2. Manually parse the HTML or strip any code tags - I'm going with this approach for now.  It's not the best approach, and it is a hack, but it will at least allow be to continue.
