### PR TITLE
Article Detail View - Building Out Functionality

### DIFF
--- a/google-news-reader/google-news-reader.xcodeproj/project.pbxproj
+++ b/google-news-reader/google-news-reader.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		5F98D1EB1B62DC1100FAB688 /* google_news_readerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F98D1EA1B62DC1100FAB688 /* google_news_readerTests.swift */; };
 		5F98D1F61B62DC1100FAB688 /* google_news_readerUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F98D1F51B62DC1100FAB688 /* google_news_readerUITests.swift */; };
 		6C0797FA1B643EBB008C1B35 /* ArticleParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0797F91B643EBB008C1B35 /* ArticleParser.swift */; };
+		6C4D66D01B6592440033D31B /* ViewController+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C4D66CF1B6592440033D31B /* ViewController+Additions.swift */; };
 		6CAD41D51B64356300436298 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CAD41D41B64356300436298 /* NetworkManager.swift */; };
 		6CB0B37F1B65396D00FC969C /* Article+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB0B37D1B65396D00FC969C /* Article+CoreDataProperties.swift */; };
 		6CB0B3801B65396D00FC969C /* Article.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB0B37E1B65396D00FC969C /* Article.swift */; };
@@ -57,6 +58,7 @@
 		5F98D1F51B62DC1100FAB688 /* google_news_readerUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = google_news_readerUITests.swift; sourceTree = "<group>"; };
 		5F98D1F71B62DC1100FAB688 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6C0797F91B643EBB008C1B35 /* ArticleParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ArticleParser.swift; path = API/ArticleParser.swift; sourceTree = "<group>"; };
+		6C4D66CF1B6592440033D31B /* ViewController+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "ViewController+Additions.swift"; path = "Extensions/ViewController+Additions.swift"; sourceTree = "<group>"; };
 		6CAD41D41B64356300436298 /* NetworkManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetworkManager.swift; path = API/NetworkManager.swift; sourceTree = "<group>"; };
 		6CB0B37D1B65396D00FC969C /* Article+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Article+CoreDataProperties.swift"; path = "Models/Article+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		6CB0B37E1B65396D00FC969C /* Article.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Article.swift; path = Models/Article.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 		5F98D1D11B62DC1100FAB688 /* google-news-reader */ = {
 			isa = PBXGroup;
 			children = (
+				6C1D23C11B65920700D3BED3 /* Extensions */,
 				6CB0B37C1B65395B00FC969C /* Models */,
 				6CAD41D31B64354900436298 /* API */,
 				6CDBDE791B64872900D1CBD3 /* Controllers */,
@@ -145,6 +148,14 @@
 				5F98D1F71B62DC1100FAB688 /* Info.plist */,
 			);
 			path = "google-news-readerUITests";
+			sourceTree = "<group>";
+		};
+		6C1D23C11B65920700D3BED3 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				6C4D66CF1B6592440033D31B /* ViewController+Additions.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 		6CAD41D31B64354900436298 /* API */ = {
@@ -324,6 +335,7 @@
 			files = (
 				6CDBDE7B1B64879300D1CBD3 /* ArticleListTableViewController.swift in Sources */,
 				6CAD41D51B64356300436298 /* NetworkManager.swift in Sources */,
+				6C4D66D01B6592440033D31B /* ViewController+Additions.swift in Sources */,
 				6C0797FA1B643EBB008C1B35 /* ArticleParser.swift in Sources */,
 				5F98D1D31B62DC1100FAB688 /* AppDelegate.swift in Sources */,
 				6CB0B3891B65790800FC969C /* ArticleHeaderTableViewCell.swift in Sources */,

--- a/google-news-reader/google-news-reader/Base.lproj/Main.storyboard
+++ b/google-news-reader/google-news-reader/Base.lproj/Main.storyboard
@@ -28,7 +28,7 @@
                             <outlet property="delegate" destination="zLX-wl-yDe" id="YSJ-rT-wRy"/>
                         </connections>
                     </tableView>
-                    <navigationItem key="navigationItem" title="Root View Controller" id="KLq-Tf-bnj" userLabel="Google News Reader"/>
+                    <navigationItem key="navigationItem" title="Google News Feed" id="KLq-Tf-bnj" userLabel="Google News Reader"/>
                     <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="bUu-Gx-yJS">
                         <autoresizingMask key="autoresizingMask"/>
                         <connections>
@@ -43,16 +43,16 @@
             </objects>
             <point key="canvasLocation" x="715" y="253"/>
         </scene>
-        <!--Article Detail Table View Controller-->
+        <!--Article Detail-->
         <scene sceneID="Mkx-ob-pW2">
             <objects>
-                <tableViewController id="MPO-hk-rVb" customClass="ArticleDetailTableViewController" customModule="google_news_reader" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="qmh-Ri-lhB">
+                <tableViewController title="Article Detail" id="MPO-hk-rVb" customClass="ArticleDetailTableViewController" customModule="google_news_reader" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="qmh-Ri-lhB">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="articleHeader" rowHeight="88" id="uaz-O4-7Dg" customClass="ArticleHeaderTableViewCell" customModule="google_news_reader" customModuleProvider="target">
+                            <tableViewCell clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="articleHeader" rowHeight="88" id="uaz-O4-7Dg" customClass="ArticleHeaderTableViewCell" customModule="google_news_reader" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="86" width="600" height="88"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uaz-O4-7Dg" id="1u3-4L-Kif">

--- a/google-news-reader/google-news-reader/Controllers/ArticleDetailTableViewController.swift
+++ b/google-news-reader/google-news-reader/Controllers/ArticleDetailTableViewController.swift
@@ -30,6 +30,8 @@ class ArticleDetailTableViewController: UITableViewController {
         let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: self.tableView.frame.size.width, height: webViewHeight))
         webView.loadRequest(NSURLRequest(URL: NSURL(string: (self.article?.articleURL)!)!))
         
+        webView.navigationDelegate = self
+        
         self.tableView.tableFooterView = webView
     }
 
@@ -109,4 +111,15 @@ class ArticleDetailTableViewController: UITableViewController {
     }
     */
 
+}
+
+extension ArticleDetailTableViewController: WKNavigationDelegate {
+    func webView(webView: WKWebView, didCommitNavigation navigation: WKNavigation!) {
+        print("didCommitNavigation: \(navigation)")
+    }
+    
+    func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
+        print("didFinishNavigation: \(navigation)")
+        // stop spinner here
+    }
 }

--- a/google-news-reader/google-news-reader/Controllers/ArticleDetailTableViewController.swift
+++ b/google-news-reader/google-news-reader/Controllers/ArticleDetailTableViewController.swift
@@ -12,6 +12,7 @@ import WebKit
 class ArticleDetailTableViewController: UITableViewController {
     
     var article: Article?
+    let spinner = UIActivityIndicatorView(activityIndicatorStyle: UIActivityIndicatorViewStyle.WhiteLarge)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -33,6 +34,13 @@ class ArticleDetailTableViewController: UITableViewController {
         webView.navigationDelegate = self
         
         self.tableView.tableFooterView = webView
+        
+        // set up activity indicator for web view loading
+        self.spinner.center = self.view.center
+        self.spinner.color = UIColor.purpleColor()
+        self.view.addSubview(self.spinner)
+        self.view.bringSubviewToFront(self.spinner)
+        self.spinner.startAnimating()
     }
 
     override func didReceiveMemoryWarning() {
@@ -55,7 +63,6 @@ class ArticleDetailTableViewController: UITableViewController {
 
         // Configure the cell...
         cell.articleTitleLabel.text = self.article?.title
-//        cell.articleDateLabel.text = ""
         
         if let imageObj = self.article?.image {
             if let image: UIImage = imageObj as? UIImage {
@@ -66,60 +73,13 @@ class ArticleDetailTableViewController: UITableViewController {
         return cell
     }
 
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
-    }
-    */
-
-    /*
-    // Override to support editing the table view.
-    override func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
-        if editingStyle == .Delete {
-            // Delete the row from the data source
-            tableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: .Fade)
-        } else if editingStyle == .Insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }    
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(tableView: UITableView, moveRowAtIndexPath fromIndexPath: NSIndexPath, toIndexPath: NSIndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(tableView: UITableView, canMoveRowAtIndexPath indexPath: NSIndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
-        // Get the new view controller using segue.destinationViewController.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }
 
 extension ArticleDetailTableViewController: WKNavigationDelegate {
-    func webView(webView: WKWebView, didCommitNavigation navigation: WKNavigation!) {
-        print("didCommitNavigation: \(navigation)")
-    }
     
     func webView(webView: WKWebView, didFinishNavigation navigation: WKNavigation!) {
-        print("didFinishNavigation: \(navigation)")
-        // stop spinner here
+        // stop spinner
+        spinner.stopAnimating()
+        spinner.hidden = true
     }
 }

--- a/google-news-reader/google-news-reader/Controllers/ArticleDetailTableViewController.swift
+++ b/google-news-reader/google-news-reader/Controllers/ArticleDetailTableViewController.swift
@@ -82,4 +82,20 @@ extension ArticleDetailTableViewController: WKNavigationDelegate {
         spinner.stopAnimating()
         spinner.hidden = true
     }
+    
+    func webView(webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: NSError) {
+        print(error)
+        
+        var userMessage: String?
+        
+        switch error.code {
+        case NSURLErrorNotConnectedToInternet:
+            userMessage = NetworkError.NetworkFailure.localizedDescription
+        
+        default:
+            userMessage = NetworkError.UnknownError.localizedDescription
+        }
+        
+        self.alertUserWithTitleAndMessage("Error", message: userMessage)
+    }
 }

--- a/google-news-reader/google-news-reader/Controllers/ArticleDetailTableViewController.swift
+++ b/google-news-reader/google-news-reader/Controllers/ArticleDetailTableViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import WebKit
 
 class ArticleDetailTableViewController: UITableViewController {
     
@@ -23,6 +24,13 @@ class ArticleDetailTableViewController: UITableViewController {
         
         self.tableView.estimatedRowHeight = 88.0
         self.tableView.rowHeight = UITableViewAutomaticDimension
+        
+        let webViewHeight = self.tableView.frame.size.height - self.tableView.estimatedRowHeight - (self.navigationController?.navigationBar.frame.size.height)! - UIApplication.sharedApplication().statusBarFrame.height
+        
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: self.tableView.frame.size.width, height: webViewHeight))
+        webView.loadRequest(NSURLRequest(URL: NSURL(string: (self.article?.articleURL)!)!))
+        
+        self.tableView.tableFooterView = webView
     }
 
     override func didReceiveMemoryWarning() {
@@ -55,10 +63,6 @@ class ArticleDetailTableViewController: UITableViewController {
 
         return cell
     }
-    
-//    override func tableView(tableView: UITableView, heightForRowAtIndexPath indexPath: NSIndexPath) -> CGFloat {
-//        return 88.0
-//    }
 
     /*
     // Override to support conditional editing of the table view.

--- a/google-news-reader/google-news-reader/Extensions/ViewController+Additions.swift
+++ b/google-news-reader/google-news-reader/Extensions/ViewController+Additions.swift
@@ -1,0 +1,20 @@
+//
+//  ViewController+Additions.swift
+//  google-news-reader
+//
+//  Created by Josh Lieberman on 7/26/15.
+//  Copyright © 2015 Lieberman. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+    
+    func alertUserWithTitleAndMessage(title: String?, message: String?) {
+        
+        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
+        alert.addAction(UIAlertAction(title: "Ok", style: UIAlertActionStyle.Default, handler: nil))
+        
+        self.presentViewController(alert, animated: true, completion: nil)
+    }
+}


### PR DESCRIPTION
The Article Detail view is roughly functionally complete.

I use a table view controller with a single cell to display the title of the article and a larger view of the thumbnail.  I make the table view's footer a WKWebView to load the article.

Even if I knew a few publications' DOMs, It would be nearly impossible to parse every possible website or APIS articles could be hosted on.  So I'm falling back on a web view.

TODO: web view delegate callbacks, maybe throw in a spinner to indicate that the article webpage is loading.
